### PR TITLE
fix: add `packages=` field to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,6 @@ setuptools.setup(
     url="https://github.com/determined-ai/devcluster/",
     description="Developer tool for running the Determined cluster",
     python_requires=">=3.6",
+    packages=["devcluster"],
     entry_points={"console_scripts": ["devcluster = devcluster.__main__:main"]},
 )


### PR DESCRIPTION
Under pyenv, `pip install`ing this package does not install the actual python module unless you explicitly specify `packages` field. 
It seems either explicit `packages` or `find_packages` are required.