### PR TITLE
fix: better wait logic for bootstrapping postgres

### DIFF
--- a/devcluster/config.py
+++ b/devcluster/config.py
@@ -156,11 +156,12 @@ class DBConfig(StageConfig):
                 "kill_signal": "TERM",
                 "run_args": run_args,
                 "post": [
+                    {"logcheck": {"regex": "listening on IP"}},
                     {
                         "logcheck": {
                             "regex": "database system is ready to accept connections"
                         }
-                    }
+                    },
                 ],
             }
         )

--- a/devcluster/config.py
+++ b/devcluster/config.py
@@ -157,11 +157,6 @@ class DBConfig(StageConfig):
                 "run_args": run_args,
                 "post": [
                     {"logcheck": {"regex": "listening on IP"}},
-                    {
-                        "logcheck": {
-                            "regex": "database system is ready to accept connections"
-                        }
-                    },
                 ],
             }
         )


### PR DESCRIPTION
# Description

When postgres starts up the first time and runs boostrapping script, its messages are a bit weird. Among other things, it logs that the "database system is ready to accept connections". That allows master stage to start, and then it fails cause it can't connect to postgres.
`conncheck` wasn't particularly useful here, because postgres somehow still starts accepting connections on 5432 in the middle of bootstrapping. After some fiddling with the logs I've arrived to the proposed solution.

# Test plan

Run `db` and `master` stages as a oneshot on a (brand new | used) postgres data directory.
I've tested this on macOS, and in the new CircleCI thing, but please check if it works for you.