### PR TITLE
feat: oneshot servers to only exit on death.

### DIFF
--- a/devcluster/__main__.py
+++ b/devcluster/__main__.py
@@ -142,8 +142,6 @@ def main() -> None:
         if args.oneshot and args.quiet:
             print("--oneshot and --quiet don't make sense together", file=sys.stderr)
             ok = False
-        if args.oneshot and args.addr:
-            print("--oneshot requires that no addresses are provided", file=sys.stderr)
 
     if not ok:
         sys.exit(1)

--- a/devcluster/net.py
+++ b/devcluster/net.py
@@ -95,7 +95,7 @@ class OneshotCB:
             os.write(sys.stderr.fileno(), b"devcluster is up\n")
 
         # Is the cluster failing?
-        if target != self.first_target and not self.failing:
+        if target.lower() == "dead" and not self.failing:
             self.failing = True
             os.write(sys.stderr.fileno(), b"devcluster is failing\n")
             self.quit_cb()


### PR DESCRIPTION
I'd like to have oneshot devcluster (i.e. straight up logging) running in CI, which I control from the e2e test via `devcluster.Client#set_target` python API to change the stages. Specifically, kill and bring back the agent(s). So,

- make oneshot exit only when there's an actual devcluster failure (not just target stage switch).
- remove unnecessary error message about oneshot and listen addr not working together.

When we have an ability to not use stages, I'd like to turn them on/off via the `Client` similarly (e.g. via `devcluster.Client#{enable,disable}_stage`) to stop/start master while agent is still running or vice versa while using the same devcluster setup.