### PR TITLE
feat: support restarting individual stages

### DIFF
--- a/devcluster/__init__.py
+++ b/devcluster/__init__.py
@@ -20,6 +20,7 @@ from devcluster.devcluster import (
     Poll,
     Logger,
     StateMachine,
+    StateMachineHandle,
     Console,
 )
 from devcluster.atomic import (


### PR DESCRIPTION
As requested on #18.

Python API is still yet-to-come, but this lets you restart failed stages individually in the console by pressing the key associated with that stage, any time that stage is in a failed mode.  It works if the main process of the stage crashed, or if any of the pre- or post-commands failed.  If it was a post-command that failed, the process is left alone (until restart of course).

One neat feature (one sign of too much complexity?) is that now if the state machine ever hangs, you can press ctrl-d to get a state dump from the StateMachine object to the console.  This is in addition to the pre-existing SIGUSR1 handler that writes a stacktrace to file if the code ever deadlocks.  The goal is to provide tooling to classifying any bugs that slip through the cracks.