### PR TITLE
chore: remodel Status as if it were parallel

### DIFF
--- a/devcluster/__init__.py
+++ b/devcluster/__init__.py
@@ -21,7 +21,13 @@ from devcluster.config import (
 )
 from devcluster.recovery import ProcessTracker
 from devcluster.logger import Logger, Log, LogCB
-from devcluster.state_machine import StateMachine, StateMachineHandle, Status, StatusCB
+from devcluster.state_machine import (
+    StateMachine,
+    StateMachineHandle,
+    Status,
+    StageStatus,
+    StatusCB,
+)
 from devcluster.console import Console
 from devcluster.atomic import (
     AtomicOperation,


### PR DESCRIPTION
Right now devcluster still only supports standing up stages one-at-a-
time, but baking that limitation into the API seems foolish, since some
day that limitation may be removed, and when that day comes, it would be
nice to not break the API.

Refactor the Status object fed to the status callbacks so that it is
forward-compatible with that world.

The concepts of a single "target" and "stage" still exist for now, and
they're still useful for interactive use, because it's an easy way to
interact with a cluster, but ideally the devcluster API should be able
to operate in a way that those concepts can be safely ignored; i.e. if
you wanted to start/stop random stages at random times, that should be
possible from the devcluster API.

## Commentary

This is ultimately to support @stoksc's request: https://github.com/determined-ai/devcluster/pull/21#issuecomment-947902502