### PR TITLE
feat: allow stage kills and restarts via key bindings.

### DIFF
--- a/devcluster/console.py
+++ b/devcluster/console.py
@@ -195,6 +195,16 @@ class Console:
             return
         self.set_stream(idx, None)
 
+    def try_kill_stage(self, idx: int) -> None:
+        if idx >= len(self.stages):
+            return
+        self.state_machine_handle.kill_stage(idx)
+
+    def try_restart_stage(self, idx: int) -> None:
+        if idx >= len(self.stages):
+            return
+        self.state_machine_handle.restart_stage(idx)
+
     def act_scroll(self, val: int) -> None:
         self.scroll = max(0, self.scroll + val)
         self.redraw()
@@ -283,6 +293,10 @@ class Console:
                     self.act_marker()
                 elif cmdstr == ":noop":
                     self.act_noop()
+                elif cmdstr.startswith(":kill-stage:"):
+                    self.try_kill_stage(int(cmdstr[len(":kill-stage:") :]))
+                elif cmdstr.startswith(":restart-stage:"):
+                    self.try_restart_stage(int(cmdstr[len(":restart-stage:") :]))
                 else:
                     self.logger.log(
                         dc.fore_num(9)
@@ -309,6 +323,12 @@ class Console:
             self.act_scroll_reset()
         elif key == " ":
             self.act_marker()
+        else:
+            self.logger.log(
+                dc.fore_num(9)
+                + dc.asbytes(f'"{key}" is not a known shortcut\n')
+                + dc.res
+            )
 
     def handle_stdin(self, ev: int, _: int) -> None:
         if ev & dc.Poll.IN_FLAGS:

--- a/devcluster/net.py
+++ b/devcluster/net.py
@@ -237,6 +237,8 @@ class Server:
                 self.state_machine.run_command,
                 self.state_machine.quit,
                 self.state_machine.dump_state,
+                self.state_machine.kill_stage,
+                self.state_machine.restart_stage,
             )
             self.console = dc.Console(
                 self.logger,
@@ -413,6 +415,8 @@ class ConsoleClient:
             self.run_command,
             self.quit,
             self.dump_state,
+            self.kill_stage,
+            self.restart_stage,
         )
         self.console = dc.Console(
             self.logger,
@@ -507,3 +511,9 @@ class ConsoleClient:
 
     def dump_state(self) -> None:
         self.server.write({"dump_state": None})
+
+    def kill_stage(self, idx: int) -> None:
+        self.server.write({"kill_stage": {"target": idx, "signal": None}})
+
+    def restart_stage(self, idx: int) -> None:
+        self.server.write({"restart_stage": idx})

--- a/devcluster/state_machine.py
+++ b/devcluster/state_machine.py
@@ -144,11 +144,15 @@ class StateMachineHandle:
         run_command: typing.Callable[[str], None],
         quit_cb: typing.Callable[[], None],
         dump_state: typing.Callable[[], None],
+        kill_stage: typing.Callable[[int], None],
+        restart_stage: typing.Callable[[int], None],
     ):
         self.set_target_or_restart = set_target_or_restart
         self.run_command = run_command
         self.quit = quit_cb
         self.dump_state = dump_state
+        self.kill_stage = kill_stage
+        self.restart_stage = restart_stage
 
 
 class StateMachine:


### PR DESCRIPTION
Hooking up the wires to allow killing and restarting stages from the console client using custom keybindings.
`alt + number` and `alt + shift + number` keys on macos generate a spectrum of interesting symbols, so here's my example config:

```
commands:
  h: make -C harness build
  w: make -C webui build
  c: make -C docs build
  ¡: :kill-stage:1
  ™: :kill-stage:2
  £: :kill-stage:3
  ¢: :kill-stage:4
  ⁄: :restart-stage:1
  €: :restart-stage:2
  ‹: :restart-stage:3
  ›: :restart-stage:4
```