### PR TITLE
fix: old configs relying on default master.post

### DIFF
--- a/old_configs/v0.12.4.yaml
+++ b/old_configs/v0.12.4.yaml
@@ -9,6 +9,9 @@ stages:
       pre:
         - sh: make -C master build
         - sh: make -C tools prep-root
+      post:
+        - conncheck:
+            port: 8080
       config_file:
         db:
           host: localhost

--- a/old_configs/v0.12.5.yaml
+++ b/old_configs/v0.12.5.yaml
@@ -10,6 +10,9 @@ stages:
         - sh: make -C proto build
         - sh: make -C master build
         - sh: make -C tools prep-root
+      post:
+        - conncheck:
+            port: 8080
       config_file:
         db:
           host: localhost


### PR DESCRIPTION
The master's default post command changed from conncheck to logcheck at some point, causing some of the older configs to cease to work.