### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/devcluster/__init__.py
+++ b/devcluster/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 from devcluster.util import (
     asbytes,
     back_num,


### PR DESCRIPTION
- Fix an import error during initial setup with Python 3.8.
- Relax cwd checks, so pre commands can set up cwd.
- Fix some old configs that no longer worked.