### PR TITLE
chore: Bump mypy requirement to 0.991

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .
 
 black==22.3.0
-mypy==0.780
+mypy==0.991
 flake8>=3.8.0
 flake8-bugbear>=19.8.0
 flake8-builtins>=1.5.3


### PR DESCRIPTION
Resolves a clang build issue on apple silicon with python 3.9