### PR TITLE
feat: allow 'kill_signal' config for master and agent

### DIFF
--- a/devcluster/stage.py
+++ b/devcluster/stage.py
@@ -252,10 +252,12 @@ class Process(BaseProcess):
         # kill via signal
         self.dying = True
         assert self.proc
-        if sig is None:
-            self.proc.kill()
-        else:
+        if sig is not None:
             self.proc.send_signal(sig)
+        elif self.config.kill_signal is not None:
+            self.proc.send_signal(signal.Signals[self.config.kill_signal])
+        else:
+            self.proc.kill()
 
 
 class DockerProcess(BaseProcess):


### PR DESCRIPTION
Motivation behind this is adding more test coverage reporting for master / agent in e2e_tests.

Go's requirement for test coverage of a binary is that it is shutdown gracefully. 

Devcluster currently sends SIGKILLs, and to my understanding devcluster has no way to change this for non-docker stages.