### PR TITLE
chore: types and style so CI lint checks pass

### DIFF
--- a/devcluster/devcluster.py
+++ b/devcluster/devcluster.py
@@ -69,9 +69,9 @@ class Devcluster:
             name: i for i, name in enumerate(self._stage_names)
         }  # type: typing.Dict[typing.Union[str, int], int]
         self._stage_map.update({i: i for i in range(len(self._stage_names))})
-        self._target_map = {
-            i: name for i, name in enumerate(self._stage_names)
-        }  # type: typing.Dict[typing.Union[str, int], str]
+        self._target_map = dict(
+            enumerate(self._stage_names)
+        )  # type: typing.Dict[typing.Union[str, int], str]
         self._target_map.update(
             {name: name for i, name in enumerate(self._stage_names)}
         )

--- a/devcluster/logger.py
+++ b/devcluster/logger.py
@@ -44,7 +44,7 @@ class Logger:
             self.streams = init_streams
 
         if init_index is None:
-            self.index = {i: stream for i, stream in enumerate(all_streams)}
+            self.index = dict(enumerate(all_streams))
         else:
             self.index = init_index
 

--- a/devcluster/util.py
+++ b/devcluster/util.py
@@ -68,7 +68,7 @@ def terminal_config() -> typing.Iterator[None]:
     new = termios.tcgetattr(fd)
 
     # raw terminal settings from `man 3 termios`
-    new[0] = new[0] & ~(  # type: ignore
+    new[0] = new[0] & ~(
         termios.IGNBRK
         | termios.BRKINT
         | termios.PARMRK
@@ -79,9 +79,9 @@ def terminal_config() -> typing.Iterator[None]:
         | termios.IXON
     )
     # new[1] = new[1] & ~termios.OPOST;
-    new[2] = new[2] & ~(termios.CSIZE | termios.PARENB)  # type: ignore
-    new[2] = new[2] | termios.CS8  # type: ignore
-    new[3] = new[3] & ~(  # type: ignore
+    new[2] = new[2] & ~(termios.CSIZE | termios.PARENB)
+    new[2] = new[2] | termios.CS8
+    new[3] = new[3] & ~(
         termios.ECHO | termios.ECHONL | termios.ICANON | termios.ISIG | termios.IEXTEN
     )
 


### PR DESCRIPTION
Two changes:
* CI has been failing since mypy was updated in #40 (https://app.circleci.com/pipelines/github/determined-ai/devcluster/118/workflows/abb912ee-d371-418e-9ed9-4bd3b9939dbc/jobs/184). This removes the `type: ignore` directives it was complaining about

* A new version of flake8-comprehension tests for dict-comprehension patterns that old versions did not. This updates the two examples that fail.