### PR TITLE
ci: Add type stubs to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ flake8-comprehensions>=2.2.0
 flake8-docstrings>=1.4.0
 flake8-quotes>=2.1.0
 flake8-tuple>=0.4.0
+types-PyYAML
+types-setuptools


### PR DESCRIPTION
For CI to succeed, mypy needs type stubs of imported modules.