### PR TITLE
chore: bump postgres version form 10.14 -> 14.13 [CM-417]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .mypy_cache
 devcluster.egg-info
+build/
+dist/

--- a/devcluster/config.py
+++ b/devcluster/config.py
@@ -258,7 +258,7 @@ class DBConfig(StageConfig):
         self.container_name = str(config.get("container_name", "determined_db"))
         self.data_dir = read_path(config.get("data_dir"))
         self.name = str(config.get("name", "db"))
-        self.image_name = str(config.get("image_name", "postgres:13.16"))
+        self.image_name = str(config.get("image_name", "postgres:14.13"))
         self.post = config.get("post", [{"logcheck": {"regex": "listening on IP"}}])
 
         check_list_of_strings(

--- a/devcluster/config.py
+++ b/devcluster/config.py
@@ -258,7 +258,7 @@ class DBConfig(StageConfig):
         self.container_name = str(config.get("container_name", "determined_db"))
         self.data_dir = read_path(config.get("data_dir"))
         self.name = str(config.get("name", "db"))
-        self.image_name = str(config.get("image_name", "postgres:10.14"))
+        self.image_name = str(config.get("image_name", "postgres:13.16"))
         self.post = config.get("post", [{"logcheck": {"regex": "listening on IP"}}])
 
         check_list_of_strings(


### PR DESCRIPTION
## Description
With the upcoming EOL of Postgres v12 in November, we're looking to bump our minimum supported version of Postgres v14. 

## Ticket
[CM-417](https://hpe-aiatscale.atlassian.net/browse/CM-417)

[CM-417]: https://hpe-aiatscale.atlassian.net/browse/CM-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ